### PR TITLE
Allow the prefix key-binding to be customized

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,6 +69,9 @@ options.  The more interesting ones would be
 ``eyebrowse-wrap-around-p`` and ``eyebrowse-switch-back-and-forth-p``
 which affect both wrap around and lazier switching.
 
+The prefix for each binding defaults to ``C-c C-w``, but you can change
+it to something else by customizing ``eyebrowse-keymap-prefix``.
+
 If you're not happy with the default keybindings, a riskier set can be
 enabled additionally either by executing ``M-:
 (eyebrowse-setup-opinionated-keys)`` interactively or inserting

--- a/eyebrowse.el
+++ b/eyebrowse.el
@@ -47,6 +47,11 @@ manager."
   :group 'convenience
   :prefix "eyebrowse-")
 
+(defcustom eyebrowse-keymap-prefix (kbd "C-c C-w")
+  "Prefix key for key-bindings."
+  :type 'string
+  :group 'eyebrowse)
+
 (defcustom eyebrowse-lighter " ¬_¬"
   "Lighter for `eyebrowse-minor-mode'."
   :type 'string
@@ -131,15 +136,16 @@ If t, switching to the same window config as
 
 (defvar eyebrowse-mode-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "C-c C-w <") 'eyebrowse-prev-window-config)
-    (define-key map (kbd "C-c C-w >") 'eyebrowse-next-window-config)
-    (define-key map (kbd "C-c C-w '") 'eyebrowse-last-window-config)
-    (define-key map (kbd "C-c C-w \"") 'eyebrowse-close-window-config)
-    (-dotimes 10 (lambda (n)
-                   (define-key map (kbd (s-concat "C-c C-w "
-                                                  (number-to-string n)))
-                     (lambda () (interactive)
-                       (eyebrowse-switch-to-window-config n)))))
+    (let ((prefix-map (make-sparse-keymap)))
+      (define-key prefix-map (kbd "<") 'eyebrowse-prev-window-config)
+      (define-key prefix-map (kbd ">") 'eyebrowse-next-window-config)
+      (define-key prefix-map (kbd "'") 'eyebrowse-last-window-config)
+      (define-key prefix-map (kbd "\"") 'eyebrowse-close-window-config)
+      (-dotimes 10 (lambda (n)
+                     (define-key prefix-map (kbd (number-to-string n))
+                       (lambda () (interactive)
+                         (eyebrowse-switch-to-window-config n)))))
+      (define-key map eyebrowse-keymap-prefix prefix-map))
     map)
   "Current key map.  Can be set up with `eyebrowse-setup-keys'.")
 


### PR DESCRIPTION
It's currently hard-coded to `C-c C-w`, and this PR changes it so it's set to that by default, but gives the option to adjust it to taste.
