### PR TITLE
Option for not setting up evil keys

### DIFF
--- a/eyebrowse.el
+++ b/eyebrowse.el
@@ -559,14 +559,15 @@ Currently only gt, gT, gc and zx are supported."
   (define-key evil-motion-state-map (kbd "zx") 'eyebrowse-last-window-config))
 
 ;;;###autoload
-(defun eyebrowse-setup-opinionated-keys ()
+(defun eyebrowse-setup-opinionated-keys (&optional ignore-evil)
   "Set up more opinionated key bindings for using eyebrowse.
 
-M-0..M-9, C-< / C->, C-'and C-\" are used for switching.  If Evil
-is detected, extra key bindings will be set up with
-`eyebrowse-setup-evil-keys' as well."
+M-0..M-9, C-< / C->, C-'and C-\" are used for switching.  If
+IGNORE-EVIL isn't set and Evil is detected, extra key bindings
+will be set up with `eyebrowse-setup-evil-keys' as well."
   (let ((map eyebrowse-mode-map))
-    (when (bound-and-true-p evil-mode)
+    (when (and (not ignore-evil)
+               (bound-and-true-p evil-mode))
       (eyebrowse-setup-evil-keys))
     (define-key map (kbd "C-<") 'eyebrowse-prev-window-config)
     (define-key map (kbd "C->") 'eyebrowse-next-window-config)


### PR DESCRIPTION
First I want to say, thanks, fantastic package!

This MR adds an optional argument to `eyebrowse-setup-opinionated-keys` to avoid setting up the key bindings for evil. Using evil doesn't mean that you'd want these binds necessarily.

As it's an optional argument and set to ignore setting evil bindings if set, it doesn't change the api of this method and should work exactly the same for everyone, unless they're specifying this argument.

What do you think, is it reasonable or do you suggest some other solution (that may or may not involve changing eyebrowse.el).