### PR TITLE
Add option to show only current config in mode line

### DIFF
--- a/eyebrowse.el
+++ b/eyebrowse.el
@@ -95,10 +95,13 @@ nil, 'hide: Don't show at all.
 
 'smart: Hide when only one window config.
 
+'current: Only show current config.
+
 t, 'always: Always show."
   :type '(choice (const :tag "Hide" hide)
                  (const :tag "Smart" smart)
-                 (const :tag "Always" always))
+                 (const :tag "Always" always)
+                 (const :tag "Current" current))
   :group 'eyebrowse)
 
 (defcustom eyebrowse-wrap-around nil
@@ -607,7 +610,9 @@ will be set up with `eyebrowse-setup-evil-keys' as well."
          (separator (propertize eyebrowse-mode-line-separator
                                 'face 'eyebrowse-mode-line-separator))
          (current-slot (eyebrowse--get 'current-slot))
-         (window-configs (eyebrowse--get 'window-configs)))
+         (window-configs (if (eq eyebrowse-mode-line-style 'current)
+                             `(,(nth (- (eyebrowse--get 'current-slot) 1) (eyebrowse--get 'window-configs)))
+                           (eyebrowse--get 'window-configs))))
     (if (and eyebrowse-mode-line-style
              (not (eq eyebrowse-mode-line-style 'hide))
              (or (and (not (eq eyebrowse-mode-line-style 'smart))

--- a/eyebrowse.el
+++ b/eyebrowse.el
@@ -611,7 +611,7 @@ will be set up with `eyebrowse-setup-evil-keys' as well."
                                 'face 'eyebrowse-mode-line-separator))
          (current-slot (eyebrowse--get 'current-slot))
          (window-configs (if (eq eyebrowse-mode-line-style 'current)
-                             `(,(nth (- current-slot 1) (eyebrowse--get 'window-configs)))
+                             `(,(assq current-slot (eyebrowse--get 'window-configs)))
                            (eyebrowse--get 'window-configs))))
     (if (and eyebrowse-mode-line-style
              (not (eq eyebrowse-mode-line-style 'hide))

--- a/eyebrowse.el
+++ b/eyebrowse.el
@@ -611,7 +611,7 @@ will be set up with `eyebrowse-setup-evil-keys' as well."
                                 'face 'eyebrowse-mode-line-separator))
          (current-slot (eyebrowse--get 'current-slot))
          (window-configs (if (eq eyebrowse-mode-line-style 'current)
-                             `(,(assq current-slot (eyebrowse--get 'window-configs)))
+                             (list (assoc current-slot (eyebrowse--get 'window-configs)))
                            (eyebrowse--get 'window-configs))))
     (if (and eyebrowse-mode-line-style
              (not (eq eyebrowse-mode-line-style 'hide))

--- a/eyebrowse.el
+++ b/eyebrowse.el
@@ -611,7 +611,7 @@ will be set up with `eyebrowse-setup-evil-keys' as well."
                                 'face 'eyebrowse-mode-line-separator))
          (current-slot (eyebrowse--get 'current-slot))
          (window-configs (if (eq eyebrowse-mode-line-style 'current)
-                             `(,(nth (- (eyebrowse--get 'current-slot) 1) (eyebrowse--get 'window-configs)))
+                             `(,(nth (- current-slot 1) (eyebrowse--get 'window-configs)))
                            (eyebrowse--get 'window-configs))))
     (if (and eyebrowse-mode-line-style
              (not (eq eyebrowse-mode-line-style 'hide))


### PR DESCRIPTION
Sometimes I rename all my window-configs and mode-line becomes really long. It's barely readable when I have two windows side-by-side. This commit adds option to show only current window-config.

What do you think? I will update README if you think it's a good idea. 