### PR TITLE
Inhibit message to echo area

### DIFF
--- a/eyebrowse.el
+++ b/eyebrowse.el
@@ -286,7 +286,8 @@ with the scratch buffer."
        (let* ((buffer-name (cadr item))
               (buffer (get-buffer buffer-name)))
          (when (not buffer)
-           (message "Replaced deleted %s buffer with *scratch*" buffer-name)
+           (let ((inhibit-message t))
+             (message "Replaced deleted %s buffer with *scratch*" buffer-name))
            (setf (cadr item) "*scratch*")))))))
 
 (defun eyebrowse--rename-window-config-buffers (window-config old new)


### PR DESCRIPTION
Hi. I try to keep my echo area free of unnecessary messages when I start emacs. This message shows up a lot when using eyebrowse w/persp-mode, as layouts from the last session are restored. Would it be possible to redirect this to just the `*Messages*` buffer?